### PR TITLE
makes 1.3 compatible while maintaining 1.2 backwards compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
       <artifactId>clojure</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>tools.macro</artifactId>
+      <version>0.1.1</version>
+    </dependency>
+    <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
       <version>0.9.94</version>

--- a/src/pallet/thread_expr.clj
+++ b/src/pallet/thread_expr.clj
@@ -1,6 +1,6 @@
 (ns pallet.thread-expr
   "Macros that can be used in an expression thread."
-  (:require [clojure.contrib.macro-utils :as macro]))
+  (:require [clojure.tools.macro :as macro]))
 
 (letfn [(for- [threader arg seq-exprs body]
           `(reduce #(%2 %1)
@@ -379,7 +379,7 @@
             (+ x y)))
         (+ 1))
  => 12
-    
+
       (--> 5
            (expose-request-as [x] (+ x))
            (+ 1))
@@ -419,7 +419,7 @@
              (+ x y)))
          (+ 1))
  => 12
-    
+
       (-->> 5
             (expose-request-as [x] (+ x))
             (+ 1))

--- a/test/pallet/thread_expr_test.clj
+++ b/test/pallet/thread_expr_test.clj
@@ -49,7 +49,7 @@
 (deftest let->>test
   (is (= 2) (->> 1 (let->> [a 1] (+ a)))))
 
-(def *a* 0)
+(def ^{:dynamic true} *a* 0)
 (deftest binding->test
   (is (= 2) (-> 1 (binding-> [*a* 1] (+ *a*)))))
 


### PR DESCRIPTION
Just had to replace `clojure.contrib.macro-utils` with the newer `clojure.tools.macro` library.  I found it odd that the pom didn't list `clojure.contrib` as a dep even though the project clearly depended on it.  Anwyays, I've added `clojure.tools.macro` as a dep now and have verifed that the tests pass with both clojure 1.2 and 1.3.
